### PR TITLE
ci: test docker/setup-docker-action on bare metal macOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -30,6 +30,9 @@ jobs:
           fetch-tags: true
 
       - uses: docker/setup-docker-action@v5
+        id: docker
+        with:
+          set-host: true
 
       - name: Docker spot checks
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,8 @@ jobs:
       matrix:
         runner:
           # - ubuntu-latest
-          - macos-26-intel
+          # - macos-26-intel
+          - macos-26-m5
         suite: [reviewable]
     steps:
       - uses: actions/checkout@v6

--- a/pkg/crid/docker/docker.go
+++ b/pkg/crid/docker/docker.go
@@ -115,6 +115,11 @@ func Detect(ctx context.Context, name, dataDir string) backend.Backend {
 		filepath.Join(home, ".rd", "docker.sock"),
 	}
 
+	// Prepend DOCKER_HOST socket if set (e.g. docker/setup-docker-action)
+	if dh := os.Getenv("DOCKER_HOST"); strings.HasPrefix(dh, "unix://") {
+		paths = append([]string{strings.TrimPrefix(dh, "unix://")}, paths...)
+	}
+
 	socket := func() *string {
 		for _, s := range paths {
 			if _, err := os.Stat(s); err == nil {


### PR DESCRIPTION
## Summary
- Test `docker/setup-docker-action@v5` on `macos-26-m5` bare metal runner (dedicated `runner` user, ephemeral mode)
- Commented out `macos-26-intel` and `ubuntu-latest` to isolate the test

## Test plan
- [ ] Verify `docker/setup-docker-action` succeeds on bare metal macOS
- [ ] Check Docker spot checks pass
- [ ] If green, re-enable other runners

🤖 Generated with [Claude Code](https://claude.com/claude-code)